### PR TITLE
Patch 4.1

### DIFF
--- a/src/handlers/discord/userStateHandler.js
+++ b/src/handlers/discord/userStateHandler.js
@@ -1,4 +1,4 @@
-const {convertVolumeToPercentage, imageToBase64, logIt, createStates} = require("../../utils/helpers.js");
+const {convertVolumeToPercentage, imageToBase64, logIt, createStates, diff} = require("../../utils/helpers.js");
 
 class UserStateHandler {
   constructor(TPClient, DG) {
@@ -6,6 +6,7 @@ class UserStateHandler {
     this.TPClient = TPClient;
     this.DG = DG;
     this.base64Avatar = "iVBORw0KGgoAAAANSUhEUgAAAIAAAACAAgMAAAC+UIlYAAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAlQTFRFAAAAAAAAAAAAg2PpwAAAAAN0Uk5TAAIBv0eWygAAADdJREFUeJztziEBACAMAEHWgerrgacSIWjAFAbu9YmPVhQAAAAAAAAAAAAA8DDo6wxyjusPH4ANKzEDgZ7ZsS4AAAAASUVORK5CYII=";
+    this.oldUserData = {};
   }
 
   updateParticipantCount = async () => {
@@ -26,27 +27,59 @@ class UserStateHandler {
   };
 
   addUserData = async (data) => {
-    if (!this.DG.currentVoiceUsers.hasOwnProperty(data.user.id)) {
+    let userId = data.user.id;
+
+    // Initialize user if it doesn't exist
+    if (!this.DG.currentVoiceUsers.hasOwnProperty(userId)) {
       logIt("DEBUG", `User ${data.nick} has joined the voice channel`);
       this.updateParticipantCount();
+      this.DG.currentVoiceUsers[userId] = {};
     }
-    // Updating User Data in the currentVoiceUsers object
-    this.DG.currentVoiceUsers[data.user.id] = data;
+  
+    const user = this.DG.currentVoiceUsers[userId];
+    if (user.base64Avatar === undefined) {
+      const avatarUrl = `https://cdn.discordapp.com/avatars/${userId}/${data.user.avatar}.webp?size=128`;
+      user.base64Avatar = await imageToBase64(avatarUrl);
+    }
+  
+    this.DG.currentVoiceUsers[userId] = {
+      ...data,
+      base64Avatar: user.base64Avatar
+    };
   };
 
   generateUserUpdates(userIndex, user, idPrefix = "user") {
-    return [
-      { id: `${idPrefix}_${userIndex}_deaf`, value: user.voice_state.deaf ? "On" : "Off" },
-      { id: `${idPrefix}_${userIndex}_self_deaf`, value: user.voice_state.self_deaf ? "On" : "Off" },
-      { id: `${idPrefix}_${userIndex}_self_mute`, value: user.voice_state.self_mute ? "On" : "Off" },
-      { id: `${idPrefix}_${userIndex}_mute`, value: user.mute ? "On" : "Off" },
-      { id: `${idPrefix}_${userIndex}_server_mute`, value: user.voice_state.mute ? "On" : "Off" },
-      { id: `${idPrefix}_${userIndex}_id`, value: user.user.id },
-      { id: `${idPrefix}_${userIndex}_nick`, value: user.nick },
-      // { id: `${idPrefix}_${userIndex}_volume`, value: Math.round(user.volume) },
-      { id: `${idPrefix}_${userIndex}_avatar`, value: user.base64Avatar },
-      { id: `${idPrefix}_${userIndex}_avatarID`, value: user.user.avatar }
-    ];
+    // Only push updates for the states that have changed
+    const updates = [];
+
+    if (user.voice_state && user.voice_state.deaf !== undefined) {
+      updates.push({ id: `${idPrefix}_${userIndex}_deaf`, value: user.voice_state.deaf ? "On" : "Off" });
+    }
+    if (user.voice_state && user.voice_state.self_deaf !== undefined) {
+      updates.push({ id: `${idPrefix}_${userIndex}_self_deaf`, value: user.voice_state.self_deaf ? "On" : "Off" });
+    }
+    if (user.voice_state && user.voice_state.self_mute !== undefined) {
+      updates.push({ id: `${idPrefix}_${userIndex}_self_mute`, value: user.voice_state.self_mute ? "On" : "Off" });
+    }
+    if (user.mute !== undefined) {
+      updates.push({ id: `${idPrefix}_${userIndex}_mute`, value: user.mute ? "On" : "Off" });
+    }
+    if (user.voice_state && user.voice_state.mute !== undefined) {
+      updates.push({ id: `${idPrefix}_${userIndex}_server_mute`, value: user.voice_state.mute ? "On" : "Off" });
+    }
+    if (user.user && user.user.id !== undefined) {
+      updates.push({ id: `${idPrefix}_${userIndex}_id`, value: user.user.id });
+    }
+    if (user.nick !== undefined) {
+      updates.push({ id: `${idPrefix}_${userIndex}_nick`, value: user.nick });
+    }
+    if (user.base64Avatar !== undefined) {
+      updates.push({ id: `${idPrefix}_${userIndex}_avatar`, value: user.base64Avatar });
+    }
+    if (user.user && user.user.avatar !== undefined) {
+      updates.push({ id: `${idPrefix}_${userIndex}_avatarID`, value: user.user.avatar });
+    }
+    return updates;
 }
 
   updateUserStates = async (data) => {
@@ -57,28 +90,31 @@ class UserStateHandler {
       const userId = data.user.id;
       const userIndex = Object.keys(this.DG.currentVoiceUsers).indexOf(userId);
       const user = this.DG.currentVoiceUsers[userId];
+      const previousUserData = this.oldUserData[userId] || {};
+
+      // Get the difference between the previous user data and the current user data
+      const userDiff = diff(previousUserData, user);
 
       // Now check if there are 11 or more users in the channel, if so, we need to create more user states
       if (Object.keys(this.DG.currentVoiceUsers).length >= 11) {
         createStates(`user_${userIndex}`, this.DG.DEFAULT_USER_STATES, `VC | User_${userIndex}`, this.TPClient);
       }
 
-      // If user doesn't have a base64Avatar from previous update, we fetch it and add it to the user object
-      if (user.base64Avatar === undefined) {
-        const avatarUrl = `https://cdn.discordapp.com/avatars/${userId}/${user.user.avatar}.webp?size=128`;
-        user.base64Avatar = await imageToBase64(avatarUrl);
+      // Updating general user states
+      let updates = this.generateUserUpdates(userIndex, userDiff);
+
+      // Only updating user volume connector/state if volume has changed
+      if (userDiff.hasOwnProperty("volume")) {
+        let newVolume = convertVolumeToPercentage(user.volume) / 2;
+        this.TPClient.connectorUpdate(`discord_voice_volume_action_connector|voiceUserList_connector=${userIndex}`, newVolume);
+        updates.push({ id: `user_${userIndex}_volume`, value: Math.round(newVolume) })
       }
 
-      // Updating general user states
-      let updates = this.generateUserUpdates(userIndex, user);
-      // Check and update volume if changed
-      let newVolume = convertVolumeToPercentage(user.volume) / 2;
-      this.TPClient.connectorUpdate(`discord_voice_volume_action_connector|voiceUserList_connector=${userIndex}`, newVolume);
-      logIt("DEBUG", `User ${data.nick} has updated their volume to ${newVolume}`);
+      // Updating states for general user
+      if (updates.length > 0) {
+        this.TPClient.stateUpdateMany(updates);
+      }
 
-      updates.push({ id: `user_${userIndex}_volume`, value: Math.round(newVolume) })
-
-      this.TPClient.stateUpdateMany(updates);
       // Update custom voice activity users if applicable
       if (this.DG.customVoiceAcivityUsers.hasOwnProperty(userId)) {
         let customUserIndex = this.DG.customVoiceAcivityUsers[userId];
@@ -88,6 +124,9 @@ class UserStateHandler {
     } catch (error) {
       logIt("ERROR", `updateUserStates: ${error}`);
     }
+
+    // Keeping track of previous user data
+    this.oldUserData[data.user.id] = this.DG.currentVoiceUsers[data.user.id]
   };
 
   deleteUserStates = async (data) => {

--- a/src/handlers/discord/voiceChannelHandler.js
+++ b/src/handlers/discord/voiceChannelHandler.js
@@ -99,7 +99,9 @@ class VoiceChannelHandler {
         if (this.DG.currentVoiceUsers[key].user.id !== this.DG.Client.user.id) {
           // When we join a voice channel, update the states for all users in the channel
           let states = this.userStateHandler.generateUserUpdates(i, this.DG.currentVoiceUsers[key], "user");
-          this.TPClient.stateUpdateMany(states);
+          if (states.length > 0) {
+            this.TPClient.stateUpdateMany(states);
+          }
         }
       });
 

--- a/src/index.js
+++ b/src/index.js
@@ -209,7 +209,7 @@ TPClient.on("ConnectorChange", (data) => {
         newVol = Math.max(0, Math.min(newVol, 100)) * 2;
         const userId = getUserIdFromIndex(data.data[0].value, DG.currentVoiceUsers);
         if (userId !== undefined) {
-          logIt("INFO", "Setting Voice Volume for ", userId, " to ", newVol);
+          logIt("DEBUG", "Setting Voice Volume for ", userId, " to ", newVol/2);
           DG.Client.setUserVoiceSettings(userId, {
             volume: convertPercentageToVolume(newVol),
           });


### PR DESCRIPTION
# userStateHandler
- added a check for user data changes in voiceChats before sending updates
- fixed 3081 error caused by updating mute 10+ times which triggered a connector update
- fixed issue causing base64 conversion of user avatar on every single user update that occured, in some cases this affect with plugin performance.

# voiceStateHandler.js
- fixed issue when user  would undeafen, mute stays on via discord but plugin shows false
We now check the previous deaf/mute state to determine if we should or should not be turning off mute and or deafen...
Scenario: When setting mute - > deafen - > undeafen would result in mutestate being turned off although it wasnt in discord..

# index.js
- changed logging for setting voice volume to DEBUG

# voiceChannelHandler.js
- added a check before updating states to make object is not empty.